### PR TITLE
Add required PowerShell version information.

### DIFF
--- a/Update-ArcDPS.ps1
+++ b/Update-ArcDPS.ps1
@@ -49,6 +49,17 @@ param(
     [switch]$uninstall = $false
 )
 
+'Update-ArcDPS - ArcDPS Auto-Updater'
+Write-Host -ForegroundColor Cyan "                by Frisky.7952"
+''
+$versionMinimum = [Version]'4.0.0.0'
+"PowerShell required version: $versionMinimum"
+"         Running PowerShell: $($PSVersionTable.PSVersion)"
+if ($versionMinimum -gt $PSVersionTable.PSVersion) {
+     Write-Host -ForegroundColor Red "Error: Requires at least PowerShell version $versionMinimum to run."
+     exit
+}
+
 $ArcDPS_Site = "https://www.deltaconnected.com/arcdps/x64/"
 $ArcDPS_DLL = "d3d9.dll"
 $ArcDPS_HashFile = $ArcDPS_DLL + ".md5sum"


### PR DESCRIPTION
Prints a message when the program runs that informs the user of the required version of PowerShell.

This prevents the awful PowerShell 4-line red messages as a result of running an older version of PowerShell.